### PR TITLE
Escapes quote character in filename.

### DIFF
--- a/lib/git-tab-status.coffee
+++ b/lib/git-tab-status.coffee
@@ -43,6 +43,7 @@ class GitTabStatus
 
     _findTabForPath: (path) ->
         path = path.replace /\\/g, '\\\\'
+        path = path.replace(/[']/g, "\\$&")
         $(".tab [data-path='#{path}']")
 
 module.exports = new GitTabStatus()


### PR DESCRIPTION
This works on Mac, I have not (yet) had a chance to tests if this has averse side-effects on Windows and Linux. I'll check those as soon as I get a chance to set up VirtualBox (or someone else checks this before I do).

Patch for issue #9